### PR TITLE
fix: swift-internals repository has been migrated to https://github.c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [英文原版在线版](https://swift.org/documentation/api-design-guidelines/)
 
-[网站的 GitHub 仓库地址](https://github.com/apple/swift-internals/blob/gh-pages/api-design-guidelines/index.md)
+[网站的 GitHub 仓库地址](https://github.com/apple/swift-org-website/blob/main/documentation/api-design-guidelines/index.md)
 
 ## 更新记录
 


### PR DESCRIPTION
[apple/swift-org-website](https://github.com/apple/swift-internals) is archived and has been migrated to [apple/swift-org-website](https://github.com/apple/swift-org-website).

Fix readme link.